### PR TITLE
Add warning and reminder on conflicting docker ports

### DIFF
--- a/src/consume/2_instructions/3_workbench.md
+++ b/src/consume/2_instructions/3_workbench.md
@@ -63,6 +63,18 @@ reference the [](how-to-get-help) section of this manual.
 You need to be in the root directory of the LX in order to run the `dts code` commands.
 ```
 
+:::{trouble}
+
+These errors appear: `requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http+docker://localhost/v1.43/containers/84ce.../start`
+
+and it is complained that certain ports are in conflict and could not be used.
+
+---
+
+Please check your running docker containers and ports with: `docker ps --format "table {{.Names}}\t{{.Image}}\t{{.ID}}\t{{.Ports}}"`
+And stop the ones unnecessary, that occupy the mentioned conflicted ports.
+:::
+
 ## Extra Options
 
 ```{warning}


### PR DESCRIPTION
Added this warning for `dts code workbench --sim` based on user feedback:
![image](https://github.com/duckietown/book-devmanual-lx/assets/10885835/a511bff7-2d09-4977-96f3-73872f96cd06)
